### PR TITLE
Set default application config to use FPL system update user and FPL OAuth client

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,11 +3,11 @@ spring.application.name=fpl-ccd-data-migration-tool
 log.debug=false
 
 idam.api.url=http://localhost:4501
-idam.client.id=ccd_gateway
+idam.client.id=fpl
 idam.client.secret=OOOOOOOOOOOOOOOO
-idam.client.redirect_uri=http://localhost:3451/oauth2redirect
-idam.username=sam@hillingdon.gov.uk
-idam.password=Password12
+idam.client.redirect_uri=https://localhost:9000/oauth2/callback
+idam.username=FPL_SYSTEM_UPDATE
+idam.password=FPL_SYSTEM_UPDATE
 
 idam.s2s-auth.microservice=fpl_case_service
 idam.s2s-auth.totp_secret=AABBCCDDEEFFGGHH


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Change that adds FPL OAuth client is here: https://github.com/hmcts/fpl-ccd-configuration/pull/339

There is no change that adds FPL system update user as it should be in TIDAM image that I will push next week.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```