### PR TITLE
chore: Create jar file with unique version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 plugins {
   id 'application'
   id 'org.springframework.boot' version '2.1.6.RELEASE'
 }
 
 group = 'uk.gov.hmcts.reform'
-version = '1.0.0'
+version = "1.0.0-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("ddMMYYYY-HHMM"))
 
 sourceCompatibility = '11'
 targetCompatibility = '11'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'uk.gov.hmcts.reform'
-version = "1.0.0-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("ddMMYYYY-HHMM"))
+version = "1.0.0-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("YYYYMMdd-HHMM"))
 
 sourceCompatibility = '11'
 targetCompatibility = '11'


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated `build.gradle` file to add current date time to the version number. This is to make sure we always create jar files with unique names for data migration requests and don't have to check the last used version number.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
