### PR TITLE
migration: Remove supporting evidence bundle (FPLA-3037)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -3,17 +3,16 @@ package uk.gov.hmcts.reform.migration.service;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
 @Service
 public class DataMigrationServiceImpl implements DataMigrationService<Map<String, Object>> {
-    List<Long> caseIds = List.of(1616408548410918L);
+    Long caseId = 1616408548410918L;
 
     @Override
     public Predicate<CaseDetails> accepts() {
-        return caseDetails -> caseIds.contains(caseDetails.getId());
+        return caseDetails -> caseId.equals(caseDetails.getId());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.migration.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+@Service
+public class DataMigrationServiceImpl implements DataMigrationService<Map<String, Object>> {
+    List<Long> caseIds = List.of(1616408548410918L);
+
+    @Override
+    public Predicate<CaseDetails> accepts() {
+        return caseDetails -> caseIds.contains(caseDetails.getId());
+    }
+
+    @Override
+    public Map<String, Object> migrate(Map<String, Object> data) {
+        return Map.of("migrationId", "FPLA-3037");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPLA-3037](https://tools.hmcts.net/jira/browse/FPLA-3037)


### Change description ###
Removes a corrupted supporting evidence bundle that is preventing the user from send judicial messages related to the application.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
