### PR TITLE
chore(deps): ccd-case-migration:domain from 2.1.0 to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
   compile group: 'uk.gov.hmcts.reform.ccd-case-migration', name: 'processor', version: '3.0.0'
-  compile group: 'uk.gov.hmcts.reform.ccd-case-migration', name: 'domain', version: '2.1.0'
+  compile group: 'uk.gov.hmcts.reform.ccd-case-migration', name: 'domain', version: '3.0.0'
   compile group: 'com.google.guava', name: 'guava', version: '28.0-jre'
 
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.5.0'


### PR DESCRIPTION
bump domain lib to 3.0.0 so that it doesn't have to be added in each pr
