### PR TITLE
chore(docs): expand readme and add unpopulated service

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Note that the parameters given are using AAT environment as an example.
 
 ## Common issues
 
+### Running
+
+When running the migration we are making the requests as the system user, as such if the user does not have
+[permission](https://github.com/hmcts/fpl-ccd-configuration/blob/master/ccd-definition/AuthorisationCaseField/CareSupervision/system-update.json)
+to the fields that it needs to update then the ccd-data-store-api could return errors when validating the case data at
+the end of the migration. To ensure that this doesn't occur make sure that the system user has access to all fields
+being operated on in both the
+[DataMigrationServiceImpl](src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java)
+and the
+[controller](https://github.com/hmcts/fpl-ccd-configuration/blob/master/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java)
+handling the callback.
+
+### Dependencies
+
 With the deprecation of JCenter the dependencies
 
 ```groovy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fpl-ccd-data-migration-tool
+# FPL CCD Data Migration Tool
 
 For more info on the tool and how to use it check out https://github.com/hmcts/ccd-case-migration-starter
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
 # fpl-ccd-data-migration-tool
+
+For more info on the tool and how to use it check out https://github.com/hmcts/ccd-case-migration-starter
+
+## Build
+
+To build the project run
+
+```shell
+./gradlew clean build
+```
+
+this will generate a jar in the `build/libs` directory which can then be used when running the migration.
+
+## Running
+
+To run the jar you will need to do the following
+
+```shell
+java -jar \
+-Dspring.application.name="fpl-ccd-case-migration-tool" \
+-Didam.api.url="https://idam-api.aat.platform.hmcts.net" \
+-Didam.client.id="fpl_case_service" \
+-Didam.client.secret="[VALUE IN VAULT]" \
+-Didam.client.redirect_uri="https://fpl-case-service-aat.service.core-compute-aat.internal/oauth2/callback" \
+-Dcore_case_data.api.url="http://ccd-data-store-api-aat.service.core-compute-aat.internal" \
+-Didam.s2s-auth.url="http://rpe-service-auth-provider-aat.service.core-compute-aat.internal" \
+-Didam.s2s-auth.microservice="fpl_case_service" \
+-Didam.s2s-auth.totp_secret="[VALUE IN VAULT]" \
+-Dmigration.idam.username="fpl-system-update@mailnesia.com" \
+-Dmigration.idam.password="[VALUE IN VAULT]" \
+-Dmigration.jurisdiction="PUBLICLAW" \
+-Dmigration.caseType="CARE_SUPERVISION_EPO" \
+-Dlogging.level.root="ERROR" \
+-Dlogging.level.uk.gov.hmcts.reform="INFO" \
+-Dfeign.client.config.default.connectTimeout="60000" \
+-Dfeign.client.config.default.readTimeout="60000" \
+PATH/TO/MIGRATION.jar
+```
+
+where
+
+- `idam.client.secret`
+- `idam.s2s-auth.totp_secret`
+- `migration.idam.password`
+
+can all be found in the fpl-case-service vault.
+
+Note that the parameters given are using AAT environment as an example.
+
+## Common issues
+
+With the deprecation of JCenter the dependencies
+
+```groovy
+compile group: 'uk.gov.hmcts.reform.ccd-case-migration', name: 'processor', version: '3.0.0'
+compile group: 'uk.gov.hmcts.reform.ccd-case-migration', name: 'domain', version: '3.0.0'
+```
+
+are not available to be downloaded, to ensure that you can build and run migrations you can clone
+the [stater repo](https://github.com/hmcts/ccd-case-migration-starter) and compile the dependencies locally using
+
+```shell
+./gradlew clean build publishToMavenLocal
+```

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.migration.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+@Service
+public class DataMigrationServiceImpl implements DataMigrationService<Map<String, Object>> {
+    @Override
+    public Predicate<CaseDetails> accepts() {
+        // Implement filter here that selects the cases to be migrated
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public Map<String, Object> migrate(Map<String, Object> data) {
+        // Populate a map here with data that wants to be present when connecting with the callback service
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.migration.service;
 
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.Map;
 import java.util.function.Predicate;
 
-@Service
+@Component
 public class DataMigrationServiceImpl implements DataMigrationService<Map<String, Object>> {
     @Override
     public Predicate<CaseDetails> accepts() {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -8,15 +8,27 @@ import java.util.function.Predicate;
 
 @Component
 public class DataMigrationServiceImpl implements DataMigrationService<Map<String, Object>> {
+
+    private static final String MIGRATION_ID = "YOUR_MIGRATION_ID_HERE";
+
     @Override
     public Predicate<CaseDetails> accepts() {
-        // Implement filter here that selects the cases to be migrated
+        /*
+         Implement filter here that selects the cases to be migrated.
+        */
         throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
     public Map<String, Object> migrate(Map<String, Object> data) {
-        // Populate a map here with data that wants to be present when connecting with the callback service
-        throw new UnsupportedOperationException("not yet implemented");
+        /*
+         Populate a map here with data that wants to be present when connecting with the callback service.
+
+         With the current implementation of the migration controller in
+         https://github.com/hmcts/fpl-ccd-configuration/blob/master/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+         we require a migration id to be passed to then pass to the appropriate method in the controller.
+         The controller then cleans up this id so that it is no longer present in the case data.
+        */
+        return Map.of("migrationId", MIGRATION_ID);
     }
 }


### PR DESCRIPTION
Updated README to give info on how to build and run the migration tool as well as some common errors that may occur during compilation.

Added skeleton service for all others to be based on.
