### PR TITLE
DFPL-1431: Only send the set of migrated fields over to the data-store

### DIFF
--- a/charts/fpl-cron-ccd-data-migration-tool/values.preview.template.yaml
+++ b/charts/fpl-cron-ccd-data-migration-tool/values.preview.template.yaml
@@ -7,6 +7,8 @@ job:
   concurrencyPolicy: Forbid
   environment:
     IDAM_REDIRECT_URL: https://fpl-case-service-*.service.core-compute-aat.internal/oauth2/callback
+    IDAM_S2S_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
+    IDAM_API_URL: https://idam-api.aat.platform.hmcts.net
 
 global:
   jobKind: CronJob

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -23,6 +23,8 @@
     <cve>CVE-2022-31690</cve>
     <cve>CVE-2022-31692</cve>
     <cve>CVE-2021-37533</cve>
+    <cve>CVE-2023-20860</cve>
+    <cve>CVE-2023-20863</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -25,6 +25,8 @@
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2023-20860</cve>
     <cve>CVE-2023-20863</cve>
+    <cve>CVE-2023-20873</cve>
+    <cve>CVE-2023-20862</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -51,10 +51,10 @@ public class CoreCaseDataService {
 
         if (dataMigrationService.accepts().test(updatedCaseDetails)) {
             log.info("Initiating updating case {}", updatedCaseDetails.getId());
-            updatedCaseDetails.getData().put(MIGRATION_ID_KEY,
-                caseDetails.getData().get(MIGRATION_ID_KEY));
-            updatedCaseDetails.getData().put(CASE_ID,
-                caseDetails.getId());
+
+            Map<String, Object> migratedFields = dataMigrationService.migrate(updatedCaseDetails.getData());
+            migratedFields.put(MIGRATION_ID_KEY, caseDetails.getData().get(MIGRATION_ID_KEY));
+            migratedFields.put(CASE_ID, caseDetails.getId());
 
             CaseDataContent caseDataContent = CaseDataContent.builder()
                 .eventToken(startEventResponse.getToken())
@@ -64,7 +64,7 @@ public class CoreCaseDataService {
                         .summary(eventSummary)
                         .description(eventDescription)
                         .build()
-                ).data(dataMigrationService.migrate(updatedCaseDetails.getData()))
+                ).data(migratedFields)
                 .build();
             return coreCaseDataApi.submitEventForCaseWorker(
                 AuthUtil.getBearerToken(authorisation),

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -51,10 +51,12 @@ public class CoreCaseDataService {
 
         if (dataMigrationService.accepts().test(updatedCaseDetails)) {
             log.info("Initiating updating case {}", updatedCaseDetails.getId());
+            updatedCaseDetails.getData().put(MIGRATION_ID_KEY, caseDetails.getData().get(MIGRATION_ID_KEY));
+            updatedCaseDetails.getData().put(CASE_ID, caseDetails.getId());
 
             Map<String, Object> migratedFields = dataMigrationService.migrate(updatedCaseDetails.getData());
+            // Needs to be added with the fields we are migrating to send to the event
             migratedFields.put(MIGRATION_ID_KEY, caseDetails.getData().get(MIGRATION_ID_KEY));
-            migratedFields.put(CASE_ID, caseDetails.getId());
 
             CaseDataContent caseDataContent = CaseDataContent.builder()
                 .eventToken(startEventResponse.getToken())

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -103,6 +103,6 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
             log.warn("Rollback ignored {id = DFPL-1124, case reference = {}}",
                 caseId);
         }
-        return Map.of();
+        return new HashMap<>();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -90,7 +90,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
             log.warn("Migration {id = DFPL-1124, case reference = {}} doesn't have court info ",
                 caseId);
         }
-        return Map.of();
+        return new HashMap<>();
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1431


### Change description ###
 - Updates the migrate function to now return a Map<String, Object> that contains only the fields that have changed (+ the migrationId)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
