### PR TITLE
DFPL-1463: Add migration function + use court field exists query

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -39,14 +39,15 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         "DFPL-1124", this::run1124,
         "DFPL-log", this::triggerOnlyMigration,
         "DFPL-1124Rollback", this::run1124Rollback,
-        "DFPL-GSWA", this::triggerOnlyMigration,
+        "DFPL-702", this::triggerOnlyMigration,
         "DFPL-1352", this::triggerOnlyMigration
     );
 
     private final Map<String, EsQuery> queries = Map.of(
         "DFPL-1124", this.query1124(),
         "DFPL-1124Rollback", this.topLevelFieldExistsQuery(DFJ_AREA),
-        "DFPL-log", this.topLevelFieldExistsQuery(COURT)
+        "DFPL-log", this.topLevelFieldExistsQuery(COURT),
+        "DFPL-702", this.topLevelFieldExistsQuery(COURT)
     );
 
     @Override
@@ -64,11 +65,6 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         return queries.get(migrationId);
     }
 
-    public void validateQueryId(String migrationId) {
-        if (!queries.containsKey(migrationId)) {
-            throw new NoSuchElementException("No query mapped to " + migrationId);
-        }
-    }
 
     @Override
     public Predicate<CaseDetails> accepts() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1463


### Change description ###
- Setting up migration tool to run migrationId 'DFPL-702' (Global Search fields migration)
  - Only migrates those with a top level field `court`
  - No special logic in the migration tool, all exists in the fpl-case-service callback

 - _Also removes a function that wasn't being called to stop IntelliJ's warnings 😄_ 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
