### PR TITLE
Use default migration function if no explicit mapping override

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/CaseMigrationRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/CaseMigrationRunner.java
@@ -28,6 +28,7 @@ public class CaseMigrationRunner implements CommandLineRunner {
     @Value("${case-migration.processing.id}") String migrationId;
 
     @Value("${case-migration.enabled}") boolean enabled;
+    @Value("${case-migration.validateMigrationId:false}") boolean validateMigrationId;
 
     @Value("${case-migration.use_case_id_mapping:false}") boolean useIdList;
 
@@ -43,7 +44,13 @@ public class CaseMigrationRunner implements CommandLineRunner {
                 return;
             }
             log.info("Migration ID is {}", migrationId);
-            dataMigrationService.validateMigrationId(migrationId);
+
+            // if we do not validate the migration ID - fallback behaviour may be employed, passing the migrationID
+            // through to fpl-case-service (DEFAULTS TO FALSE = NO CHECKING)
+            if (validateMigrationId) {
+                dataMigrationService.validateMigrationId(migrationId);
+            }
+
             if (useIdList) {
                 // Do ID List Migration
                 List<String> caseIds = caseIdListConfiguration.getCaseIds(migrationId);

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -37,6 +37,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     private final DfjAreaLookUpService dfjAreaLookUpService;
     private final ObjectMapper objectMapper;
     private final Map<String, Function<Map<String, Object>, Map<String, Object>>> migrations = Map.of(
+        "default", this::triggerOnlyMigration,
         "DFPL-1124", this::run1124,
         "DFPL-log", this::triggerOnlyMigration,
         "DFPL-1124Rollback", this::run1124Rollback,
@@ -81,7 +82,8 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     public Map<String, Object> migrate(Map<String, Object> data, String migrationId) {
         requireNonNull(migrationId, "Migration ID must not be null");
         if (!migrations.containsKey(migrationId)) {
-            throw new NoSuchElementException("No migration mapped to " + migrationId);
+            log.info("No migration ID, falling back to default behaviour");
+            return migrations.get("default").apply(data);
         }
 
         // Perform Migration

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -115,4 +115,13 @@ class DataMigrationServiceImplTest {
 
     }
 
+    @Test
+    void shouldFallbackToDefaultMigrationIfNoIdInMapping() {
+        Map<String, Object> data = new HashMap<>();
+
+        Map<String, Object> updatedData = dataMigrationService.migrate(data, "not-in-mapping");
+
+        assertThat(updatedData).isEqualTo(Map.of());
+    }
+
 }


### PR DESCRIPTION
### Jira link (if applicable)
TBC


### Change description ###
 - If we don't define a migrationId in our mapping, then use the default pass-through to fpl-case-service behaviour.
 - This will save a PR to this repository every time we want to run a default migration.
 - Can override this behaviour by adding a new function in.
 - Can enable STRICT validation checking for safety reasons (out of hours migrations/large migrations?) using the `case-migration.validateMigrationId` configuration.

