### PR TITLE
DFPL-2031: Add global timeout and thread delay parameters

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/migration/CaseMigrationProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/CaseMigrationProcessorTest.java
@@ -78,10 +78,12 @@ class CaseMigrationProcessorTest {
             idamRepository,
             DEFAUT_QUERY_SIZE,
             DEFAULT_THREAD_LIMIT,
+            0,
             MIGRATION_ID,
             CASE_JURISDICTION,
             CASE_TYPE,
-            false);
+            false,
+            120);
     }
 
     @Test
@@ -180,10 +182,12 @@ class CaseMigrationProcessorTest {
             idamRepository,
             10,
             DEFAULT_THREAD_LIMIT,
+            0,
             "Test",
             CASE_JURISDICTION,
             null,
-            false);
+            false,
+            120);
         assertThatThrownBy(() -> caseMigrationProcessor.migrateQuery(BooleanQuery.builder().build()))
             .isInstanceOf(NullPointerException.class);
     }
@@ -195,10 +199,12 @@ class CaseMigrationProcessorTest {
             idamRepository,
             10,
             DEFAULT_THREAD_LIMIT,
+            0,
             "Test",
             CASE_JURISDICTION,
             CASE_TYPE,
-            false);
+            false,
+            120);
         assertThatThrownBy(() -> caseMigrationProcessor.migrateQuery(null))
             .isInstanceOf(NullPointerException.class);
     }
@@ -210,10 +216,12 @@ class CaseMigrationProcessorTest {
             idamRepository,
             10,
             DEFAULT_THREAD_LIMIT,
+            0,
             null,
             CASE_JURISDICTION,
             CASE_TYPE,
-            false);
+            false,
+            120);
         assertThatThrownBy(() -> caseMigrationProcessor.migrateQuery(BooleanQuery.builder().build()))
             .isInstanceOf(NullPointerException.class);
     }


### PR DESCRIPTION
### Jira link (if applicable)
[DFPL-2031](https://tools.hmcts.net/jira/browse/DFPL-2031)


### Change description ###
 - Parameterise the global migration timeout (default = 120 mins)
 - Add parameter for pausing between case migrations, to slow down the tool

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
