### PR TITLE
[DFPL-2527] Migration to remove temporary manage order fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -37,7 +37,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     private final ObjectMapper objectMapper;
     private final Map<String, Function<Map<String, Object>, Map<String, Object>>> migrations = Map.of(
         "DFPL-log", this::triggerOnlyMigration,
-        "DFPL-2491", this::triggerOnlyMigration
+        "DFPL-2527", this::triggerOnlyMigration
         );
 
     private final Map<String, EsQuery> queries = Map.of(


### PR DESCRIPTION
### Jira link
See [DFPL-2527](https://tools.hmcts.net/jira/browse/DFPL-2527)

### Change description
Migration to remove temporary manage order fields

### Testing done
Tested locally to ensure that manageOrdersOperationClosedState field had been removed from the case data and that the Judicial user was now able to create/upload from Manage Orders.

