### PR TITLE
DFPL-2572: Retain and Dispose migration

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
+++ b/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.fpl.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Element<T> {
+    private UUID id;
+
+    @NotNull
+    @Valid
+    private T value;
+
+    public static <T> Element<T> newElement(T value) {
+        return Element.<T>builder().value(value).build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
+++ b/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 import javax.validation.Valid;
@@ -12,6 +13,7 @@ import javax.validation.constraints.NotNull;
 @Data
 @Builder(toBuilder = true)
 @AllArgsConstructor
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Element<T> {
     private UUID id;

--- a/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
+++ b/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
@@ -1,15 +1,13 @@
 package uk.gov.hmcts.reform.fpl.model.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.UUID;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 @Data
 @Builder(toBuilder = true)

--- a/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
+++ b/src/main/java/uk/gov/hmcts/reform/fpl/model/common/Element.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.fpl.model.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -54,7 +54,7 @@ public class CoreCaseDataService {
             log.info("Initiating updating case {}", updatedCaseDetails.getId());
 
             Map<String, Object> migratedFields = dataMigrationService.migrate(
-                updatedCaseDetails.getData(),
+                updatedCaseDetails,
                 migrationId);
             migratedFields.put(MIGRATION_ID_KEY, migrationId);
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationService.java
@@ -3,12 +3,10 @@ package uk.gov.hmcts.reform.migration.service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.migration.query.EsQuery;
 
-import java.util.Map;
 import java.util.function.Predicate;
 
 public interface DataMigrationService<T> {
     String MIGRATION_ID_KEY = "migrationId";
-    String CASE_ID = "id";
 
     Predicate<CaseDetails> accepts();
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationService.java
@@ -12,7 +12,7 @@ public interface DataMigrationService<T> {
 
     Predicate<CaseDetails> accepts();
 
-    T migrate(Map<String, Object> data, String migrationId);
+    T migrate(CaseDetails caseDetails, String migrationId);
 
     void validateMigrationId(String migrationId);
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -174,9 +174,9 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         HashMap<String, Object> ttlMap = new HashMap<>();
 
         if (caseDetails.getData().containsKey("TTL")) {
-            ttlMap.put("OverrideTTL", caseDetails.getData().get("OverrideTTL"));
+            ttlMap.put("OverrideTTL", caseDetails.getData().getOrDefault("OverrideTTL", null));
             ttlMap.put("Suspended", "Yes");
-            ttlMap.put("SystemTTL", caseDetails.getData().get("SystemTTL"));
+            ttlMap.put("SystemTTL", caseDetails.getData().getOrDefault("SystemTTL", null));
         } else {
             ttlMap.put("OverrideTTL", null);
             ttlMap.put("Suspended", "Yes");

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -30,9 +30,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     public static final String COURT = "court";
     private final Map<String, Function<Map<String, Object>, Map<String, Object>>> migrations = Map.of(
         "DFPL-log", this::triggerOnlyMigration,
-        "DFPL-2585", this::triggerOnlyMigration,
-        "DFPL-2597", this::triggerOnlyMigration,
-        "DFPL-2605", this::triggerOnlyMigration
+        "DFPL-2610", this::triggerOnlyMigration
         );
 
     private final Map<String, EsQuery> queries = Map.of(

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -171,9 +171,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         HashMap<String, Object> ttlMap = new HashMap<>();
 
         if (caseDetails.getData().containsKey("TTL")) {
-            ttlMap.put("OverrideTTL", caseDetails.getData().getOrDefault("OverrideTTL", null));
-            ttlMap.put("Suspended", "Yes");
-            ttlMap.put("SystemTTL", caseDetails.getData().getOrDefault("SystemTTL", null));
+            ttlMap.replace("Suspended", "Yes");
         } else {
             ttlMap.put("OverrideTTL", null);
             ttlMap.put("Suspended", "Yes");

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -121,7 +121,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
                 ttlMap.put("SystemTTL", addDaysAndConvertToString(
                     caseDetails.getCreatedDate().toLocalDate(), 180));
                 break;
-            case "Submitted", "Gatekeeping", "GATEKEEPING_LISTING", "Returned":
+            case "Submitted", "Gatekeeping", "GATEKEEPING_LISTING", "RETURNED":
                 LocalDate dateSubmitted = convertValueToLocalDate(caseDetails.getData().get("dateSubmitted"));
 
                 ttlMap.put("SystemTTL", addDaysAndConvertToString(dateSubmitted, 6575));
@@ -136,7 +136,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
 
                 ttlMap.put("SystemTTL", convertValueToLocalDate(closedCaseDate).plusDays(6575));
                 break;
-            case "CASE_MANAGEMENT", "FINAL_HEARING":
+            case "PREPARE_FOR_HEARING", "FINAL_HEARING":
                 if (caseDetails.getData().get("orderCollection") == null) {
                     dateSubmitted = convertValueToLocalDate(caseDetails.getData().get("dateSubmitted"));
                     ttlMap.put("SystemTTL", addDaysAndConvertToString(dateSubmitted, 6575));

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.model.common.Element;

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -116,7 +116,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
 
         ObjectMapper objectMapper = new ObjectMapper();
 
-        switch(caseDetails.getState()){
+        switch (caseDetails.getState()) {
             case "Deleted":
                 //Check for deleted from returned
                 break;
@@ -159,8 +159,8 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
                 ttlMap.put("SystemTTL", convertValueToLocalDate(lastIssuedDate).plusDays(6575));
                 break;
             default:
-                throw new AssertionError(format("Migration 2572, case with id: %s " +
-                    "not in valid state for TTL migration", caseDetails.getId()));
+                throw new AssertionError(format("Migration 2572, case with id: %s "
+                    + "not in valid state for TTL migration", caseDetails.getId()));
         }
 
         HashMap<String, Object> updates = new HashMap<>();
@@ -168,7 +168,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         return updates;
     }
 
-    public Map<String, Object> triggerSuspendTTLMigration(CaseDetails caseDetails) {
+    public Map<String, Object> triggerSuspendMigrationTTL(CaseDetails caseDetails) {
         HashMap<String, Object> updates = new HashMap<>();
         HashMap<String, Object> ttlMap = new HashMap<>();
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -152,7 +152,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
                         getApprovalDateOnElement(element1)
                             .compareTo(getApprovalDateOnElement(element2)));
 
-                    LocalDate localDate = getApprovalDateOnElement(orderCollection.get(orderCollection.size() -1));
+                    LocalDate localDate = getApprovalDateOnElement(orderCollection.get(orderCollection.size() - 1));
                     ttlMap.put("SystemTTL", addDaysAndConvertToString(localDate, 6575));
                 }
                 break;

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -57,7 +57,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     }
 
     private EsQuery openCases() {
-        final MatchQuery openState = MatchQuery.of("state", "OPEN");
+        final MatchQuery openState = MatchQuery.of("state", "Open");
 
         return BooleanQuery.builder()
             .must(Must.builder()

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -38,7 +38,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     public static final String COURT = "court";
     private final Map<String, Function<CaseDetails, Map<String, Object>>> migrations = Map.of(
         "DFPL-log", this::triggerOnlyMigration,
-        "DFPL-2572", this::triggerRemoveMigrationTtl
+        "DFPL-2572", this::triggerTtlMigration
         );
 
     private final Map<String, EsQuery> queries = Map.of(

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -117,16 +117,10 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         ObjectMapper objectMapper = new ObjectMapper();
 
         switch (caseDetails.getState()) {
-            case "Deleted":
-                //Check for deleted from returned
-                break;
-            case "Returned":
-                //Check for Returned from deleted
-                break;
             case "Open":
                 ttlMap.put("SystemTTL", caseDetails.getCreatedDate().toLocalDate().plusDays(180));
                 break;
-            case "Submitted", "Gatekeeping", "GATEKEEPING_LISTING":
+            case "Submitted", "Gatekeeping", "GATEKEEPING_LISTING", "Returned":
                 Object dateSubmitted = caseDetails.getData().get("dateSubmitted");
 
                 ttlMap.put("SystemTTL", convertValueToLocalDate(dateSubmitted).plusDays(6575));

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -200,12 +200,10 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     }
 
     public Map<String, Object> triggerRemoveMigrationTtl(CaseDetails caseDetails) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        HashMap<String, Object> updates = objectMapper.convertValue(caseDetails.getData(),
-            new TypeReference<HashMap<String, Object>>() {});
+        HashMap<String, Object> updates = new HashMap<>();
 
         if (caseDetails.getData().containsKey("TTL")) {
-            updates.remove("TTL");
+            updates.put("TTL", null);
         }
 
         return updates;

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -169,8 +169,11 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     public Map<String, Object> triggerSuspendMigrationTtl(CaseDetails caseDetails) {
         HashMap<String, Object> updates = new HashMap<>();
         HashMap<String, Object> ttlMap = new HashMap<>();
+        ObjectMapper objectMapper = new ObjectMapper();
 
         if (caseDetails.getData().containsKey("TTL")) {
+            ttlMap = objectMapper.convertValue(caseDetails.getData().get("TTL"),
+                new TypeReference<HashMap<String, Object>>() {});
             ttlMap.replace("Suspended", "Yes");
         } else {
             ttlMap.put("OverrideTTL", null);
@@ -179,6 +182,34 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         }
 
         updates.put("TTL", ttlMap);
+        return updates;
+    }
+
+    public Map<String, Object> triggerResumeMigrationTtl(CaseDetails caseDetails) {
+        HashMap<String, Object> updates = new HashMap<>();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        if (caseDetails.getData().containsKey("TTL")) {
+            HashMap<String, Object> ttlMap = objectMapper.convertValue(caseDetails.getData().get("TTL"),
+                new TypeReference<HashMap<String, Object>>() {});
+            ttlMap.replace("Suspended", "No");
+            updates.put("TTL", ttlMap);
+        }
+
+        return updates;
+    }
+
+    public Map<String, Object> triggerRemoveMigrationTtl(CaseDetails caseDetails) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        HashMap<String, Object> updates = objectMapper.convertValue(caseDetails.getData(),
+            new TypeReference<HashMap<String, Object>>() {});
+
+        if (caseDetails.getData().containsKey("TTL")) {
+            HashMap<String, Object> ttlMap = objectMapper.convertValue(caseDetails.getData().get("TTL"),
+                new TypeReference<HashMap<String, Object>>() {});
+            ttlMap.remove("TTL");
+        }
+
         return updates;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -36,7 +36,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     public static final String COURT = "court";
     private final Map<String, Function<CaseDetails, Map<String, Object>>> migrations = Map.of(
         "DFPL-log", this::triggerOnlyMigration,
-        "DFPL-2572", this::triggerTTLMigration
+        "DFPL-2572", this::triggerTtlMigration
         );
 
     private final Map<String, EsQuery> queries = Map.of(
@@ -109,7 +109,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         return new HashMap<>();
     }
 
-    public Map<String, Object> triggerTTLMigration(CaseDetails caseDetails) {
+    public Map<String, Object> triggerTtlMigration(CaseDetails caseDetails) {
         HashMap<String, Object> ttlMap = new HashMap<>();
         ttlMap.put("OverrideTTL", null);
         ttlMap.put("Suspend", "NO");
@@ -168,7 +168,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
         return updates;
     }
 
-    public Map<String, Object> triggerSuspendMigrationTTL(CaseDetails caseDetails) {
+    public Map<String, Object> triggerSuspendMigrationTtl(CaseDetails caseDetails) {
         HashMap<String, Object> updates = new HashMap<>();
         HashMap<String, Object> ttlMap = new HashMap<>();
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -205,9 +205,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
             new TypeReference<HashMap<String, Object>>() {});
 
         if (caseDetails.getData().containsKey("TTL")) {
-            HashMap<String, Object> ttlMap = objectMapper.convertValue(caseDetails.getData().get("TTL"),
-                new TypeReference<HashMap<String, Object>>() {});
-            ttlMap.remove("TTL");
+            updates.remove("TTL");
         }
 
         return updates;

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -193,10 +193,13 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     }
 
     public LocalDate getApprovalDateOnElement(Element<Map<String, Object>> element) {
-        if (isEmpty(element.getValue().get("approvalDate"))) {
+        if (!isEmpty(element.getValue().get("approvalDateTime"))) {
             return LocalDateTime.parse(element.getValue().get("approvalDateTime").toString()).toLocalDate();
-        } else {
+        } else if (!isEmpty(element.getValue().get("approvalDate"))) {
             return convertValueToLocalDate(element.getValue().get("approvalDate"));
+        } else {
+            return LocalDate.parse(element.getValue().get("dateOfIssue").toString(),
+                DateTimeFormatter.ofPattern("d MMMM yyyy"));
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.reform.migration.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.migration.query.BooleanQuery;
 import uk.gov.hmcts.reform.migration.query.EsQuery;
 import uk.gov.hmcts.reform.migration.query.ExistsQuery;
@@ -13,6 +16,8 @@ import uk.gov.hmcts.reform.migration.query.MatchQuery;
 import uk.gov.hmcts.reform.migration.query.Must;
 import uk.gov.hmcts.reform.migration.query.MustNot;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +25,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 @Slf4j
@@ -28,9 +34,9 @@ import static java.util.Objects.requireNonNull;
 public class DataMigrationServiceImpl implements DataMigrationService<Map<String, Object>> {
 
     public static final String COURT = "court";
-    private final Map<String, Function<Map<String, Object>, Map<String, Object>>> migrations = Map.of(
+    private final Map<String, Function<CaseDetails, Map<String, Object>>> migrations = Map.of(
         "DFPL-log", this::triggerOnlyMigration,
-        "DFPL-2610", this::triggerOnlyMigration
+        "DFPL-2572", this::triggerTTLMigration
         );
 
     private final Map<String, EsQuery> queries = Map.of(
@@ -70,14 +76,14 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
     }
 
     @Override
-    public Map<String, Object> migrate(Map<String, Object> data, String migrationId) {
+    public Map<String, Object> migrate(CaseDetails caseDetails, String migrationId) {
         requireNonNull(migrationId, "Migration ID must not be null");
         if (!migrations.containsKey(migrationId)) {
             throw new NoSuchElementException("No migration mapped to " + migrationId);
         }
 
         // Perform Migration
-        return migrations.get(migrationId).apply(data);
+        return migrations.get(migrationId).apply(caseDetails);
     }
 
     private EsQuery topLevelFieldExistsQuery(String field) {
@@ -98,8 +104,65 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
             .build();
     }
 
-    private Map<String, Object> triggerOnlyMigration(Map<String, Object> data) {
+    private Map<String, Object> triggerOnlyMigration(CaseDetails caseDetails) {
         // do nothing
         return new HashMap<>();
+    }
+
+    private Map<String, Object> triggerTTLMigration(CaseDetails caseDetails) {
+        HashMap<String, Object> ttlMap = new HashMap();
+        ttlMap.put("OverrideTTL", null);
+        ttlMap.put("Suspend", "NO");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        switch(caseDetails.getState()){
+            case "Open":
+                ttlMap.put("SystemTTL", caseDetails.getCreatedDate().plusDays(180));
+                break;
+            case "Submitted", "Gatekeeping", "GATEKEEPING_LISTING":
+                Object dateSubmitted = caseDetails.getData().get("dateSubmitted");
+
+                ttlMap.put("SystemTTL", convertValueToLocalDate(dateSubmitted).plusDays(6575));
+                break;
+            case "CLOSED":
+                Map<String, Object> closedCase = objectMapper.convertValue(
+                    caseDetails.getData().get("closeCase"),
+                    new TypeReference<Map<String, Object>>() {}
+                );
+
+                Object closedCaseDate = closedCase.get("date");
+
+                ttlMap.put("SystemTTL", convertValueToLocalDate(closedCaseDate).plusDays(6575));
+                break;
+            case "CASE_MANAGEMENT", "FINAL_HEARING":
+                List<Element<Map<String,Object>>> orderCollection = objectMapper.convertValue(
+                    caseDetails.getData().get("orderCollection"),
+                    new TypeReference<List<Element<Map<String, Object>>>>() {}
+                );
+
+                orderCollection.sort((element1, element2) ->
+                    convertValueToLocalDate(element1.getValue().get("approvalDate"))
+                        .compareTo(convertValueToLocalDate(element2.getValue().get("approvalDate"))));
+
+                Object lastIssuedDate = orderCollection
+                    .get(orderCollection.size() - 1)
+                    .getValue()
+                    .get("approvalDate");
+
+                ttlMap.put("SystemTTL", convertValueToLocalDate(lastIssuedDate).plusDays(6575));
+                break;
+            default:
+                throw new AssertionError(format("Migration 2572, case with id: %s " +
+                    "not in valid state for TTL migration", caseDetails.getId()));
+        }
+
+        HashMap<String, Object> updates = new HashMap<>();
+        updates.put("TTL", ttlMap);
+        return updates;
+    }
+
+    public LocalDate convertValueToLocalDate(Object dateOnCase) {
+        return LocalDate.parse(dateOnCase.toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -134,9 +134,9 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
                     new TypeReference<Map<String, Object>>() {}
                 );
 
-                Object closedCaseDate = closedCase.get("date");
+                LocalDate closedCaseDate = convertValueToLocalDate(closedCase.get("date"));
 
-                ttlMap.put("SystemTTL", convertValueToLocalDate(closedCaseDate).plusDays(6575).toString());
+                ttlMap.put("SystemTTL", addDaysAndConvertToString(closedCaseDate,6575));
                 break;
             case "PREPARE_FOR_HEARING", "FINAL_HEARING":
                 if (isEmpty(caseDetails.getData().get("orderCollection"))) {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -136,7 +136,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
 
                 Object closedCaseDate = closedCase.get("date");
 
-                ttlMap.put("SystemTTL", convertValueToLocalDate(closedCaseDate).plusDays(6575));
+                ttlMap.put("SystemTTL", convertValueToLocalDate(closedCaseDate).plusDays(6575).toString());
                 break;
             case "PREPARE_FOR_HEARING", "FINAL_HEARING":
                 if (isEmpty(caseDetails.getData().get("orderCollection"))) {

--- a/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImpl.java
@@ -43,7 +43,7 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
 
     private final Map<String, EsQuery> queries = Map.of(
         "DFPL-2585", this.closedCases(),
-        "DFPL-2572", this.notDeletedCases()
+        "DFPL-2572", this.openCases()
     );
 
     private EsQuery closedCases() {
@@ -56,12 +56,12 @@ public class DataMigrationServiceImpl implements DataMigrationService<Map<String
             .build();
     }
 
-    private EsQuery notDeletedCases() {
-        final MatchQuery nonDeltedCases = MatchQuery.of("state", "DELETED");
+    private EsQuery openCases() {
+        final MatchQuery openState = MatchQuery.of("state", "OPEN");
 
         return BooleanQuery.builder()
-            .mustNot(MustNot.builder()
-                .clauses(List.of(nonDeltedCases))
+            .must(Must.builder()
+                .clauses(List.of(openState))
                 .build())
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
@@ -83,7 +83,7 @@ class CoreCaseDataServiceTest {
         assertThat(update.getData().get(MIGRATION_ID_KEY)).isEqualTo(DFPL_1124);
 
         verify(dataMigrationService).accepts();
-        verify(dataMigrationService).migrate(caseDetails3.getData(), DFPL_1124);
+        verify(dataMigrationService).migrate(caseDetails3, DFPL_1124);
         verify(coreCaseDataApi).startEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, "30",
             null, CASE_TYPE, String.valueOf(CASE_ID), EVENT_ID);
         verify(coreCaseDataApi).submitEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, USER_ID, null,
@@ -126,7 +126,7 @@ class CoreCaseDataServiceTest {
         //then
         assertThat(update).isNull();
         verify(dataMigrationService).accepts();
-        verify(dataMigrationService, never()).migrate(caseDetails3.getData(), DFPL_1124);
+        verify(dataMigrationService, never()).migrate(caseDetails3, DFPL_1124);
         verify(coreCaseDataApi).startEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, "30",
             null, CASE_TYPE, String.valueOf(CASE_ID), EVENT_ID);
         verify(coreCaseDataApi, never()).submitEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, USER_ID, null,
@@ -162,7 +162,7 @@ class CoreCaseDataServiceTest {
             .caseDetails(caseDetails)
             .build();
 
-        when(dataMigrationService.migrate(data, DFPL_1124))
+        when(dataMigrationService.migrate(caseDetails, DFPL_1124))
             .thenReturn(data);
 
         when(coreCaseDataApi.startEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, "30",

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -114,7 +114,7 @@ class DataMigrationServiceImplTest {
         closeCase.put("date", now.toString());
 
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put("closeCase", closeCase);
+        caseData.put("closeCaseTabField", closeCase);
 
         caseDetails = CaseDetails.builder()
             .data(caseData)
@@ -126,6 +126,7 @@ class DataMigrationServiceImplTest {
     @Test
     void shouldPopulateTtlOnCaseManagementCase() {
         LocalDate now = LocalDate.now();
+        LocalDateTime nowTime = LocalDateTime.now();
         LocalDate expectedSystemTtl = now.plusDays(6575);
 
         Map<String, Object> expectedTtl = new HashMap<>();
@@ -136,7 +137,7 @@ class DataMigrationServiceImplTest {
         Map<String, Object> order1 = new HashMap<>();
         order1.put("approvalDate", now.minusDays(2).toString());
         Map<String, Object> order2 = new HashMap<>();
-        order2.put("approvalDate", now.toString());
+        order2.put("approvalDateTime", nowTime.toString());
         Map<String, Object> order3 = new HashMap<>();
         order3.put("approvalDate", now.minusDays(4).toString());
 

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -5,12 +5,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -120,7 +124,7 @@ class DataMigrationServiceImplTest {
         assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
     }
 
-    /*@Test
+    @Test
     void shouldPopulateTtlOnCaseManagementCase() {
         LocalDate now = LocalDate.now();
         LocalDate expectedSystemTtl = now.plusDays(6575);
@@ -130,8 +134,16 @@ class DataMigrationServiceImplTest {
         expectedTtl.put("Suspend", "NO");
         expectedTtl.put("SystemTTL", expectedSystemTtl);
 
-        Map<String, Object> orderCollection = new HashMap<>();
-        orderCollection.put("date", now.toString());
+        Map<String, Object> order1 = new HashMap<>();
+        order1.put("approvalDate", now.minusDays(2).toString());
+        Map<String, Object> order2 = new HashMap<>();
+        order2.put("approvalDate", now.toString());
+        Map<String, Object> order3 = new HashMap<>();
+        order3.put("approvalDate", now.minusDays(4).toString());
+
+        List<Element<Map<String, Object>>> orderCollection = List.of(new Element<>(UUID.randomUUID(), order1),
+            new Element<>(UUID.randomUUID(), order2),
+            new Element<>(UUID.randomUUID(), order3));
 
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("orderCollection", orderCollection);
@@ -140,8 +152,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTtl));
-    }*/
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+    }
 
     @Test
     void shouldSetSuspendOnTtlCaseWithExistingTtl() {

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -149,7 +149,7 @@ class DataMigrationServiceImplTest {
 
         caseDetails = CaseDetails.builder()
             .data(caseData)
-            .state("CASE_MANAGEMENT").build();
+            .state("PREPARE_FOR_HEARING").build();
 
         assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
     }
@@ -169,7 +169,7 @@ class DataMigrationServiceImplTest {
 
         caseDetails = CaseDetails.builder()
             .data(caseData)
-            .state("CASE_MANAGEMENT").build();
+            .state("PREPARE_FOR_HEARING").build();
 
         assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
     }
@@ -194,7 +194,7 @@ class DataMigrationServiceImplTest {
 
         caseDetails = CaseDetails.builder()
             .data(caseData)
-            .state("CASE_MANAGEMENT").build();
+            .state("PREPARE_FOR_HEARING").build();
 
         assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
     }
@@ -210,7 +210,7 @@ class DataMigrationServiceImplTest {
 
         caseDetails = CaseDetails.builder()
             .data(caseData)
-            .state("CASE_MANAGEMENT").build();
+            .state("PREPARE_FOR_HEARING").build();
 
         assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
     }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -73,13 +73,14 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "No");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         caseDetails = CaseDetails.builder()
             .createdDate(now)
             .state("Open").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerTtlMigration(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -89,7 +90,7 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "No");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("dateSubmitted", now);
@@ -98,7 +99,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("Submitted").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerTtlMigration(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -109,7 +111,7 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "No");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> closeCase = new HashMap<>();
         closeCase.put("date", now.toString());
@@ -121,7 +123,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CLOSED").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerTtlMigration(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -133,7 +136,7 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "No");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> order1 = new HashMap<>();
         order1.put("approvalDate", now.minusDays(2).toString());
@@ -153,7 +156,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerTtlMigration(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -164,7 +168,7 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "No");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> order1 = new HashMap<>();
         order1.put("dateOfIssue", now.minusDays(2).format(DateTimeFormatter.ofPattern("d MMMM yyyy")));
@@ -184,7 +188,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerTtlMigration(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -195,7 +200,7 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "No");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("dateSubmitted", now);
@@ -204,7 +209,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerTtlMigration(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -229,7 +235,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerSuspendMigrationTtl(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -245,7 +252,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerSuspendMigrationTtl(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -270,7 +278,8 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        assertThat(dataMigrationService.triggerResumeMigrationTtl(caseDetails).equals(expectedTtl));
+        Map<String, Object> data = dataMigrationService.triggerResumeMigrationTtl(caseDetails);
+        assertThat(data.get("TTL")).isEqualTo(expectedTtl);
     }
 
     @Test
@@ -290,8 +299,7 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("PREPARE_FOR_HEARING").build();
 
-        dataMigrationService.triggerRemoveMigrationTtl(caseDetails);
-
-        assertThat(!caseDetails.getData().containsKey("TTL"));
+        Map<String, Object> data = dataMigrationService.triggerRemoveMigrationTtl(caseDetails);
+        assertThat(data.get("TTL")).isNull();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -63,7 +63,7 @@ class DataMigrationServiceImplTest {
     }
 
     @Test
-    void shouldPopulateTTLOnOpenCase() {
+    void shouldPopulateTtlOnOpenCase() {
         LocalDateTime now = LocalDateTime.now();
         LocalDate expectedSystemTTL = now.toLocalDate().plusDays(180);
         Map<String, Object> expectedTTL = new HashMap<>();
@@ -75,11 +75,11 @@ class DataMigrationServiceImplTest {
             .createdDate(now)
             .state("Open").build();
 
-        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTTL));
     }
 
     @Test
-    void shouldPopulateTTLOnSubmittedCase() {
+    void shouldPopulateTtlOnSubmittedCase() {
         LocalDate now = LocalDate.now();
         LocalDate expectedSystemTTL = now.plusDays(6575);
         Map<String, Object> expectedTTL = new HashMap<>();
@@ -94,11 +94,11 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("Submitted").build();
 
-        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTTL));
     }
 
     @Test
-    void shouldPopulateTTLOnClosedCase() {
+    void shouldPopulateTtlOnClosedCase() {
         LocalDate now = LocalDate.now();
         LocalDate expectedSystemTTL = now.plusDays(6575);
 
@@ -117,11 +117,11 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CLOSED").build();
 
-        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTTL));
     }
 
     /*@Test
-    void shouldPopulateTTLOnCaseManagementCase() {
+    void shouldPopulateTtlOnCaseManagementCase() {
         LocalDate now = LocalDate.now();
         LocalDate expectedSystemTTL = now.plusDays(6575);
 
@@ -144,7 +144,7 @@ class DataMigrationServiceImplTest {
     }*/
 
     @Test
-    void shouldSetSuspendOnTTLCaseWithExistingTTL(){
+    void shouldSetSuspendOnTtlCaseWithExistingTtl(){
         LocalDate now = LocalDate.now();
         LocalDate expectedSystemTTL = now.plusDays(6575);
 
@@ -165,11 +165,11 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerSuspendMigrationTTL(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTTL));
     }
 
     @Test
-    void shouldSetSuspendOnTTLCaseWithoutExistingTTL(){
+    void shouldSetSuspendOnTTLCaseWithoutExistingTtl(){
         Map<String, Object> expectedTTL = new HashMap<>();
         expectedTTL.put("OverrideTTL", null);
         expectedTTL.put("Suspend", "YES");
@@ -181,6 +181,6 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerSuspendMigrationTTL(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTTL));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -46,7 +46,7 @@ class DataMigrationServiceImplTest {
 
     @Test
     void shouldThrowExceptionWhenMigrationKeyIsNotSet() {
-        assertThatThrownBy(() -> dataMigrationService.migrate(Map.of(), null))
+        assertThatThrownBy(() -> dataMigrationService.migrate(caseDetails, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("Migration ID must not be null");
     }
@@ -54,7 +54,7 @@ class DataMigrationServiceImplTest {
     @Test
     void shouldThrowExceptionWhenMigrationKeyIsInvalid() {
         Map<String, Object> data = new HashMap<>();
-        assertThatThrownBy(() -> dataMigrationService.migrate(data, INVALID_MIGRATION_ID))
+        assertThatThrownBy(() -> dataMigrationService.migrate(caseDetails, INVALID_MIGRATION_ID))
             .isInstanceOf(NoSuchElementException.class)
             .hasMessage("No migration mapped to " + INVALID_MIGRATION_ID);
         assertThat(data.get(MIGRATION_ID_KEY)).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -125,8 +125,8 @@ class DataMigrationServiceImplTest {
 
     @Test
     void shouldPopulateTtlOnCaseManagementCase() {
-        LocalDate now = LocalDate.now();
-        LocalDateTime nowTime = LocalDateTime.now();
+        final LocalDate now = LocalDate.now();
+        final LocalDateTime nowTime = LocalDateTime.now();
         LocalDate expectedSystemTtl = now.plusDays(6575);
 
         Map<String, Object> expectedTtl = new HashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.fpl.model.common.Element;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +71,7 @@ class DataMigrationServiceImplTest {
         LocalDate expectedSystemTtl = now.toLocalDate().plusDays(180);
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
-        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("Suspended", "No");
         expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         caseDetails = CaseDetails.builder()
@@ -88,7 +87,7 @@ class DataMigrationServiceImplTest {
         LocalDate expectedSystemTtl = now.plusDays(6575);
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
-        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("Suspended", "No");
         expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> caseData = new HashMap<>();
@@ -108,7 +107,7 @@ class DataMigrationServiceImplTest {
 
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
-        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("Suspended", "No");
         expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> closeCase = new HashMap<>();
@@ -131,7 +130,7 @@ class DataMigrationServiceImplTest {
 
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
-        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("Suspended", "No");
         expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> order1 = new HashMap<>();
@@ -156,18 +155,38 @@ class DataMigrationServiceImplTest {
     }
 
     @Test
+    void shouldPopulateTtlOnCaseManagementCaseWithoutOrders() {
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTtl = now.plusDays(6575);
+
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspended", "No");
+        expectedTtl.put("SystemTTL", expectedSystemTtl);
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("dateSubmitted", now);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("CASE_MANAGEMENT").build();
+
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
+    }
+
+    @Test
     void shouldSetSuspendOnTtlCaseWithExistingTtl() {
         LocalDate now = LocalDate.now();
         LocalDate expectedSystemTtl = now.plusDays(6575);
 
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
-        expectedTtl.put("Suspend", "YES");
+        expectedTtl.put("Suspended", "Yes");
         expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> existingTtl = new HashMap<>();
         existingTtl.put("OverrideTTL", null);
-        existingTtl.put("Suspend", "NO");
+        existingTtl.put("Suspended", "No");
         existingTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> caseData = new HashMap<>();
@@ -184,7 +203,7 @@ class DataMigrationServiceImplTest {
     void shouldSetSuspendOnTtlCaseWithoutExistingTtl() {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
-        expectedTtl.put("Suspend", "YES");
+        expectedTtl.put("Suspended", "Yes");
         expectedTtl.put("SystemTTL", null);
 
         Map<String, Object> caseData = new HashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -215,12 +215,12 @@ class DataMigrationServiceImplTest {
         Map<String, Object> expectedTtl = new HashMap<>();
         expectedTtl.put("OverrideTTL", null);
         expectedTtl.put("Suspended", "Yes");
-        expectedTtl.put("SystemTTL", expectedSystemTtl);
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> existingTtl = new HashMap<>();
         existingTtl.put("OverrideTTL", null);
         existingTtl.put("Suspended", "No");
-        existingTtl.put("SystemTTL", expectedSystemTtl);
+        existingTtl.put("SystemTTL", expectedSystemTtl.toString());
 
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("TTL", existingTtl);
@@ -246,5 +246,52 @@ class DataMigrationServiceImplTest {
             .state("PREPARE_FOR_HEARING").build();
 
         assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
+    }
+
+    @Test
+    void shouldResumeOnCaseWithTtl() {
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTtl = now.plusDays(6575);
+
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspended", "No");
+        expectedTtl.put("SystemTTL", expectedSystemTtl.toString());
+
+        Map<String, Object> existingTtl = new HashMap<>();
+        existingTtl.put("OverrideTTL", null);
+        existingTtl.put("Suspended", "Yes");
+        existingTtl.put("SystemTTL", expectedSystemTtl.toString());
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("TTL", existingTtl);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("PREPARE_FOR_HEARING").build();
+
+        assertThat(dataMigrationService.triggerResumeMigrationTtl(caseDetails).equals(expectedTtl));
+    }
+
+    @Test
+    void shouldRemoveTtlObjectOnCase() {
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTtl = now.plusDays(6575);
+
+        Map<String, Object> existingTtl = new HashMap<>();
+        existingTtl.put("OverrideTTL", null);
+        existingTtl.put("Suspended", "Yes");
+        existingTtl.put("SystemTTL", expectedSystemTtl.toString());
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("TTL", existingTtl);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("PREPARE_FOR_HEARING").build();
+
+        dataMigrationService.triggerRemoveMigrationTtl(caseDetails);
+
+        assertThat(!caseDetails.getData().containsKey("TTL"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -165,7 +165,7 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerSuspendTTLMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerSuspendMigrationTTL(caseDetails).equals(expectedTTL));
     }
 
     @Test
@@ -181,6 +181,6 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerSuspendTTLMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerSuspendMigrationTTL(caseDetails).equals(expectedTTL));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -65,27 +65,27 @@ class DataMigrationServiceImplTest {
     @Test
     void shouldPopulateTtlOnOpenCase() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDate expectedSystemTTL = now.toLocalDate().plusDays(180);
-        Map<String, Object> expectedTTL = new HashMap<>();
-        expectedTTL.put("OverrideTTL", null);
-        expectedTTL.put("Suspend", "NO");
-        expectedTTL.put("SystemTTL", expectedSystemTTL);
+        LocalDate expectedSystemTtl = now.toLocalDate().plusDays(180);
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         caseDetails = CaseDetails.builder()
             .createdDate(now)
             .state("Open").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
     }
 
     @Test
     void shouldPopulateTtlOnSubmittedCase() {
         LocalDate now = LocalDate.now();
-        LocalDate expectedSystemTTL = now.plusDays(6575);
-        Map<String, Object> expectedTTL = new HashMap<>();
-        expectedTTL.put("OverrideTTL", null);
-        expectedTTL.put("Suspend", "NO");
-        expectedTTL.put("SystemTTL", expectedSystemTTL);
+        LocalDate expectedSystemTtl = now.plusDays(6575);
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("dateSubmitted", now);
@@ -94,18 +94,18 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("Submitted").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
     }
 
     @Test
     void shouldPopulateTtlOnClosedCase() {
         LocalDate now = LocalDate.now();
-        LocalDate expectedSystemTTL = now.plusDays(6575);
+        LocalDate expectedSystemTtl = now.plusDays(6575);
 
-        Map<String, Object> expectedTTL = new HashMap<>();
-        expectedTTL.put("OverrideTTL", null);
-        expectedTTL.put("Suspend", "NO");
-        expectedTTL.put("SystemTTL", expectedSystemTTL);
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> closeCase = new HashMap<>();
         closeCase.put("date", now.toString());
@@ -117,18 +117,18 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CLOSED").build();
 
-        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTtlMigration(caseDetails).equals(expectedTtl));
     }
 
     /*@Test
     void shouldPopulateTtlOnCaseManagementCase() {
         LocalDate now = LocalDate.now();
-        LocalDate expectedSystemTTL = now.plusDays(6575);
+        LocalDate expectedSystemTtl = now.plusDays(6575);
 
-        Map<String, Object> expectedTTL = new HashMap<>();
-        expectedTTL.put("OverrideTTL", null);
-        expectedTTL.put("Suspend", "NO");
-        expectedTTL.put("SystemTTL", expectedSystemTTL);
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspend", "NO");
+        expectedTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> orderCollection = new HashMap<>();
         orderCollection.put("date", now.toString());
@@ -140,40 +140,40 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTtl));
     }*/
 
     @Test
-    void shouldSetSuspendOnTtlCaseWithExistingTtl(){
+    void shouldSetSuspendOnTtlCaseWithExistingTtl() {
         LocalDate now = LocalDate.now();
-        LocalDate expectedSystemTTL = now.plusDays(6575);
+        LocalDate expectedSystemTtl = now.plusDays(6575);
 
-        Map<String, Object> expectedTTL = new HashMap<>();
-        expectedTTL.put("OverrideTTL", null);
-        expectedTTL.put("Suspend", "YES");
-        expectedTTL.put("SystemTTL", expectedSystemTTL);
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspend", "YES");
+        expectedTtl.put("SystemTTL", expectedSystemTtl);
 
-        Map<String, Object> existingTTL = new HashMap<>();
-        existingTTL.put("OverrideTTL", null);
-        existingTTL.put("Suspend", "NO");
-        existingTTL.put("SystemTTL", expectedSystemTTL);
+        Map<String, Object> existingTtl = new HashMap<>();
+        existingTtl.put("OverrideTTL", null);
+        existingTtl.put("Suspend", "NO");
+        existingTtl.put("SystemTTL", expectedSystemTtl);
 
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put("TTL", existingTTL);
+        caseData.put("TTL", existingTtl);
 
         caseDetails = CaseDetails.builder()
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
     }
 
     @Test
-    void shouldSetSuspendOnTTLCaseWithoutExistingTtl(){
-        Map<String, Object> expectedTTL = new HashMap<>();
-        expectedTTL.put("OverrideTTL", null);
-        expectedTTL.put("Suspend", "YES");
-        expectedTTL.put("SystemTTL", null);
+    void shouldSetSuspendOnTtlCaseWithoutExistingTtl() {
+        Map<String, Object> expectedTtl = new HashMap<>();
+        expectedTtl.put("OverrideTTL", null);
+        expectedTtl.put("Suspend", "YES");
+        expectedTtl.put("SystemTTL", null);
 
         Map<String, Object> caseData = new HashMap<>();
 
@@ -181,6 +181,6 @@ class DataMigrationServiceImplTest {
             .data(caseData)
             .state("CASE_MANAGEMENT").build();
 
-        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTTL));
+        assertThat(dataMigrationService.triggerSuspendMigrationTtl(caseDetails).equals(expectedTtl));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -300,6 +300,6 @@ class DataMigrationServiceImplTest {
             .state("PREPARE_FOR_HEARING").build();
 
         Map<String, Object> data = dataMigrationService.triggerRemoveMigrationTtl(caseDetails);
-        assertThat(data.get("TTL")).isNull();
+        assertThat(data.get("TTL")).isEqualTo(new HashMap<>());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/service/DataMigrationServiceImplTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -60,4 +62,125 @@ class DataMigrationServiceImplTest {
         assertThat(data.get(MIGRATION_ID_KEY)).isNull();
     }
 
+    @Test
+    void shouldPopulateTTLOnOpenCase() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate expectedSystemTTL = now.toLocalDate().plusDays(180);
+        Map<String, Object> expectedTTL = new HashMap<>();
+        expectedTTL.put("OverrideTTL", null);
+        expectedTTL.put("Suspend", "NO");
+        expectedTTL.put("SystemTTL", expectedSystemTTL);
+
+        caseDetails = CaseDetails.builder()
+            .createdDate(now)
+            .state("Open").build();
+
+        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+    }
+
+    @Test
+    void shouldPopulateTTLOnSubmittedCase() {
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTTL = now.plusDays(6575);
+        Map<String, Object> expectedTTL = new HashMap<>();
+        expectedTTL.put("OverrideTTL", null);
+        expectedTTL.put("Suspend", "NO");
+        expectedTTL.put("SystemTTL", expectedSystemTTL);
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("dateSubmitted", now);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("Submitted").build();
+
+        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+    }
+
+    @Test
+    void shouldPopulateTTLOnClosedCase() {
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTTL = now.plusDays(6575);
+
+        Map<String, Object> expectedTTL = new HashMap<>();
+        expectedTTL.put("OverrideTTL", null);
+        expectedTTL.put("Suspend", "NO");
+        expectedTTL.put("SystemTTL", expectedSystemTTL);
+
+        Map<String, Object> closeCase = new HashMap<>();
+        closeCase.put("date", now.toString());
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("closeCase", closeCase);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("CLOSED").build();
+
+        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+    }
+
+    /*@Test
+    void shouldPopulateTTLOnCaseManagementCase() {
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTTL = now.plusDays(6575);
+
+        Map<String, Object> expectedTTL = new HashMap<>();
+        expectedTTL.put("OverrideTTL", null);
+        expectedTTL.put("Suspend", "NO");
+        expectedTTL.put("SystemTTL", expectedSystemTTL);
+
+        Map<String, Object> orderCollection = new HashMap<>();
+        orderCollection.put("date", now.toString());
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("orderCollection", orderCollection);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("CASE_MANAGEMENT").build();
+
+        assertThat(dataMigrationService.triggerTTLMigration(caseDetails).equals(expectedTTL));
+    }*/
+
+    @Test
+    void shouldSetSuspendOnTTLCaseWithExistingTTL(){
+        LocalDate now = LocalDate.now();
+        LocalDate expectedSystemTTL = now.plusDays(6575);
+
+        Map<String, Object> expectedTTL = new HashMap<>();
+        expectedTTL.put("OverrideTTL", null);
+        expectedTTL.put("Suspend", "YES");
+        expectedTTL.put("SystemTTL", expectedSystemTTL);
+
+        Map<String, Object> existingTTL = new HashMap<>();
+        existingTTL.put("OverrideTTL", null);
+        existingTTL.put("Suspend", "NO");
+        existingTTL.put("SystemTTL", expectedSystemTTL);
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("TTL", existingTTL);
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("CASE_MANAGEMENT").build();
+
+        assertThat(dataMigrationService.triggerSuspendTTLMigration(caseDetails).equals(expectedTTL));
+    }
+
+    @Test
+    void shouldSetSuspendOnTTLCaseWithoutExistingTTL(){
+        Map<String, Object> expectedTTL = new HashMap<>();
+        expectedTTL.put("OverrideTTL", null);
+        expectedTTL.put("Suspend", "YES");
+        expectedTTL.put("SystemTTL", null);
+
+        Map<String, Object> caseData = new HashMap<>();
+
+        caseDetails = CaseDetails.builder()
+            .data(caseData)
+            .state("CASE_MANAGEMENT").build();
+
+        assertThat(dataMigrationService.triggerSuspendTTLMigration(caseDetails).equals(expectedTTL));
+    }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2572

Add migration method to migration tool service as we cannot change the TTL object inside the normal callback migration method.

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
