### PR TITLE
DFPL-3258: Bump java logging to 8.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ dependencies {
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '8.0.0'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,6 @@ dependencies {
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -198,8 +198,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-3258

Bump java-logging 6.1.9 -> 8.0.0

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change
