### PR TITLE
DFPL-3193: Update deps and CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ ext {
   springCloudVersion = '2025.0.3'
 }
 
-ext['jackson.version'] = '2.18.8'
+ext['jackson.version'] = '2.18.9'
 ext['snakeyaml.version'] = '2.0'
 ext['spring-security.version'] = '6.5.11'
 
@@ -190,7 +190,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-core', version: springSecurity
   implementation group: 'org.springframework.security', name: 'spring-security-config', version: springSecurity
 
-  implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
 
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.6.3'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ task smoke(type: Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '13.10.0'
+  toolVersion = '13.11.0'
   getConfigDirectory().set(new File(rootDir, 'config/checkstyle'))
 }
 
@@ -171,12 +171,12 @@ ext {
   junitVersion = "5.12.2"
   powermockVersion = '2.0.9'
   springSecurity   =  '6.5.11'
-  springCloudVersion = '2025.0.2'
+  springCloudVersion = '2025.0.3'
 }
 
-ext['jackson.version'] = '2.14.1'
-ext['snakeyaml.version'] = '1.33'
-ext['spring-security.version'] = '6.4.5'
+ext['jackson.version'] = '2.18.8'
+ext['snakeyaml.version'] = '2.0'
+ext['spring-security.version'] = '6.5.11'
 
 dependencies {
   implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
@@ -190,7 +190,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-core', version: springSecurity
   implementation group: 'org.springframework.security', name: 'spring-security-config', version: springSecurity
 
-  implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.6.3'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.6.3'
@@ -200,7 +200,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.5'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.3.0'
 
   implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-config', version: springSecurity
 
   implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
+  implementation 'org.apache.commons:commons-lang3:3.20.0'
 
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.6.3'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-core', version: springSecurity
   implementation group: 'org.springframework.security', name: 'spring-security-config', version: springSecurity
 
-  implementation group: 'commons-io', name: 'commons-io', version: '2.6'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.14'
 
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.6.3'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-core', version: springSecurity
   implementation group: 'org.springframework.security', name: 'spring-security-config', version: springSecurity
 
-  implementation group: 'commons-io', name: 'commons-io', version: '2.14'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
 
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.6.3'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.6.3'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,13 +11,11 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2020-7712</cve>
-    <cve>CVE-2023-35116</cve>
   </suppress>
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
-    <cve>CVE-2022-1471</cve>
     <cve>CVE-2026-33117</cve>
     <cve>CVE-2026-40974</cve>
     <cve>CVE-2026-40975</cve>
@@ -34,7 +32,6 @@
     <cve>CVE-2026-40970</cve>
     <cve>CVE-2026-22751</cve>
     <cve>CVE-2026-40971</cve>
-    <cve>CVE-2025-48924</cve>
     <cve>CVE-2026-41842</cve>
     <cve>CVE-2026-41850</cve>
     <cve>CVE-2026-41851</cve>
@@ -50,15 +47,8 @@
     <cve>CVE-2026-41838</cve>
     <cve>CVE-2026-41003</cve>
     <cve>CVE-2026-41694</cve>
-    <!-- could be resolved by upgrading spring-boot to 3.5.15 -->
     <cve>CVE-2026-41853</cve>
     <cve>CVE-2026-41854</cve>
-
-    <cve>CVE-2026-54512</cve>
-    <cve>CVE-2026-54513</cve>
-    <cve>CVE-2026-54514</cve>
-    <cve>CVE-2026-54515</cve>
-    <cve>CVE-2026-47838</cve>
     <cve>CVE-2026-41706</cve>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,42 +16,5 @@
 
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
-    <cve>CVE-2026-33117</cve>
-    <cve>CVE-2026-40974</cve>
-    <cve>CVE-2026-40975</cve>
-    <cve>CVE-2026-40972</cve>
-    <cve>CVE-2026-40973</cve>
-    <cve>CVE-2026-22748</cve>
-    <cve>CVE-2026-40976</cve>
-    <cve>CVE-2026-22746</cve>
-    <cve>CVE-2026-40977</cve>
-    <cve>CVE-2026-22733</cve>
-    <cve>CVE-2026-22732</cve>
-    <cve>CVE-2026-22731</cve>
-    <cve>CVE-2025-48976</cve>
-    <cve>CVE-2026-40970</cve>
-    <cve>CVE-2026-22751</cve>
-    <cve>CVE-2026-40971</cve>
-    <cve>CVE-2026-41842</cve>
-    <cve>CVE-2026-41850</cve>
-    <cve>CVE-2026-41851</cve>
-    <cve>CVE-2026-41840</cve>
-    <cve>CVE-2026-41841</cve>
-    <cve>CVE-2026-41843</cve>
-    <cve>CVE-2026-41844</cve>
-    <cve>CVE-2026-41852</cve>
-    <cve>CVE-2026-41848</cve>
-    <cve>CVE-2026-41846</cve>
-    <cve>CVE-2026-41845</cve>
-    <cve>CVE-2026-40988</cve>
-    <cve>CVE-2026-41838</cve>
-    <cve>CVE-2026-41003</cve>
-    <cve>CVE-2026-41694</cve>
-    <cve>CVE-2026-41853</cve>
-    <cve>CVE-2026-41854</cve>
-    <cve>CVE-2026-41706</cve>
-    <cve>CVE-2026-54399</cve>
-    <cve>CVE-2026-54428</cve>
-    <cve>CVE-2026-49844</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,7 +14,7 @@
   </suppress>
   <!--End of false positives section -->
 
-  <!--Please add all the temporary suppression under the below section-->
+  <!--Please add all the temporary suppression under the below section
   <suppress>
-  </suppress>
+  </suppress> -->
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-3193

Update Deps to match most up to date version for current spring-boot version

Note: Idam client + auth client cannot be bumped until we've upgraded to spring boot 4. Currently cloud and security are at their most up to date version for Spring 3

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change
